### PR TITLE
Add Makefile for easy development workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,53 @@
+# Makefile for substack-dl
+
+# Define the virtual environment directory
+VENV_DIR := .venv
+PYTHON := $(VENV_DIR)/bin/python
+
+# Default target
+.PHONY: help
+help:
+	@echo "Makefile for substack-dl"
+	@echo ""
+	@echo "Usage:"
+	@echo "  make setup     Install dependencies and set up the virtual environment"
+	@echo "  make run       Run the substack-dl application"
+	@echo "  make test      Run tests"
+	@echo "  make clean     Remove the virtual environment and other generated files"
+	@echo ""
+
+# Setup the virtual environment and install dependencies
+.PHONY: setup
+setup: $(VENV_DIR)/touchfile
+
+$(VENV_DIR)/touchfile: pyproject.toml poetry.lock
+	@echo ">>> Setting up virtual environment and installing dependencies..."
+	@if [ ! -d "$(VENV_DIR)" ]; then \
+		poetry config virtualenvs.in-project true; \
+		poetry install --no-root; \
+	else \
+		poetry install --no-root; \
+	fi
+	@touch $(VENV_DIR)/touchfile
+	@echo ">>> Setup complete."
+
+# Run the application
+.PHONY: run
+run: $(VENV_DIR)/touchfile
+	@echo ">>> Running substack-dl..."
+	poetry run substack-dl
+
+# Run tests
+.PHONY: test
+test: $(VENV_DIR)/touchfile
+	@echo ">>> Running tests..."
+	poetry run pytest
+
+# Clean up generated files
+.PHONY: clean
+clean:
+	@echo ">>> Cleaning up..."
+	@rm -rf $(VENV_DIR)
+	@find . -type d -name "__pycache__" -exec rm -rf {} +
+	@find . -type f -name "*.pyc" -delete
+	@echo ">>> Clean complete."

--- a/README.md
+++ b/README.md
@@ -46,9 +46,34 @@ pip install substack-dl
     ```
     This will create a virtual environment and install all necessary packages.
 
+Alternatively, you can use the provided Makefile for common development tasks:
+
+*   **Set up the environment and install dependencies:**
+    ```bash
+    make setup
+    ```
+*   **Run the application:**
+    ```bash
+    make run
+    ```
+    This is equivalent to `poetry run substack-dl` followed by your desired arguments. For example:
+    ```bash
+    make run -- --url https://yourfavoritesubstack.substack.com/
+    # or to see help
+    make run -- --help
+    ```
+*   **Run tests:**
+    ```bash
+    make test
+    ```
+*   **Clean up the environment:**
+    ```bash
+    make clean
+    ```
+
 ## Usage
 
-Once installed, you can run the tool using the `substack-dl` command.
+Once installed (either manually with Poetry or using `make setup`), you can run the tool using the `substack-dl` command (or `make run`).
 
 ### Command-Line Interface
 


### PR DESCRIPTION
This commit introduces a Makefile to simplify common development tasks:

- `make setup`: Sets up the Poetry virtual environment and installs dependencies.
- `make run`: Runs the `substack-dl` application. Arguments can be passed to the script, e.g., `make run -- --help`.
- `make test`: Executes tests using pytest.
- `make clean`: Removes the virtual environment and cached files.

The README.md has been updated to include instructions for using the Makefile.